### PR TITLE
Allow for setting of custom IBM Notifier binary names

### DIFF
--- a/Demote Admin Privileges.sh
+++ b/Demote Admin Privileges.sh
@@ -48,18 +48,18 @@ admin_to_exclude="${8}"
 ibm_notifier_path="${9}"
 
 
-# Enter the component name used in IBM Notifier if it is not standard.
+# Enter the executable name used in IBM Notifier if it is not standard.
 # Leave blank to use default name of 'IBM Notifier'
-ibm_notifier_component_name}="${10}"
+ibm_notifier_executable_name}="${10}"
 
 # Check for IBM Notifier path in parameter 9. If blank, set default path
 if [ ! "$ibm_notifier_path" ]; then
 	ibm_notifier_path="/Applications/IBM Notifier.app"
 fi
 
-# Check for IBM Notifier component name in parameter 10. If blank, set default path
-if [ ! "$ibm_notifier_component_name" ]; then
-	ibm_notifier_component_name="IBM Notifier"
+# Check for IBM Notifier executable name in parameter 10. If blank, set default path
+if [ ! "$ibm_notifier_executable_name" ]; then
+	ibm_notifier_executable_name="IBM Notifier"
 fi
 
 
@@ -149,7 +149,7 @@ prompt_with_ibmNotifier () {
 	
 	# Prompt the user
 	prompt_user() {
-		button=$( "${ibm_notifier_path}/Contents/MacOS/${ibm_notifier_component_name}" \
+		button=$( "${ibm_notifier_path}/Contents/MacOS/${ibm_notifier_executable_name}" \
 		-type "popup" \
 		-bar_title "Privileges Reminder" \
 		-subtitle "You are currently an administrator on this device.

--- a/Demote Admin Privileges.sh
+++ b/Demote Admin Privileges.sh
@@ -48,18 +48,18 @@ admin_to_exclude="${8}"
 ibm_notifier_path="${9}"
 
 
-# Enter the executable name used in IBM Notifier if it is not standard.
+# Enter the binary name used in IBM Notifier if it is not standard.
 # Leave blank to use default name of 'IBM Notifier'
-ibm_notifier_executable_name}="${10}"
+ibm_notifier_binary_name}="${10}"
 
 # Check for IBM Notifier path in parameter 9. If blank, set default path
 if [ ! "$ibm_notifier_path" ]; then
 	ibm_notifier_path="/Applications/IBM Notifier.app"
 fi
 
-# Check for IBM Notifier executable name in parameter 10. If blank, set default path
-if [ ! "$ibm_notifier_executable_name" ]; then
-	ibm_notifier_executable_name="IBM Notifier"
+# Check for IBM Notifier binary name in parameter 10. If blank, set default path
+if [ ! "$ibm_notifier_binary_name" ]; then
+	ibm_notifier_binary_name="IBM Notifier"
 fi
 
 
@@ -149,7 +149,7 @@ prompt_with_ibmNotifier () {
 	
 	# Prompt the user
 	prompt_user() {
-		button=$( "${ibm_notifier_path}/Contents/MacOS/${ibm_notifier_executable_name}" \
+		button=$( "${ibm_notifier_path}/Contents/MacOS/${ibm_notifier_binary_name}" \
 		-type "popup" \
 		-bar_title "Privileges Reminder" \
 		-subtitle "You are currently an administrator on this device.

--- a/Demote Admin Privileges.sh
+++ b/Demote Admin Privileges.sh
@@ -47,9 +47,19 @@ admin_to_exclude="${8}"
 # Leave blank to use default location of /Applications/IBM Notifier.app
 ibm_notifier_path="${9}"
 
+
+# Enter the component name used in IBM Notifier if it is not standard.
+# Leave blank to use default name of 'IBM Notifier'
+ibm_notifier_component_name}="${10}"
+
 # Check for IBM Notifier path in parameter 9. If blank, set default path
 if [ ! "$ibm_notifier_path" ]; then
 	ibm_notifier_path="/Applications/IBM Notifier.app"
+fi
+
+# Check for IBM Notifier component name in parameter 10. If blank, set default path
+if [ ! "$ibm_notifier_component_name" ]; then
+	ibm_notifier_component_name="IBM Notifier"
 fi
 
 
@@ -139,7 +149,7 @@ prompt_with_ibmNotifier () {
 	
 	# Prompt the user
 	prompt_user() {
-		button=$( "${ibm_notifier_path}/Contents/MacOS/IBM Notifier" \
+		button=$( "${ibm_notifier_path}/Contents/MacOS/${ibm_notifier_component_name}" \
 		-type "popup" \
 		-bar_title "Privileges Reminder" \
 		-subtitle "You are currently an administrator on this device.

--- a/Demote Admin Privileges.sh
+++ b/Demote Admin Privileges.sh
@@ -50,7 +50,7 @@ ibm_notifier_path="${9}"
 
 # Enter the binary name used in IBM Notifier if it is not standard.
 # Leave blank to use default name of 'IBM Notifier'
-ibm_notifier_binary_name}="${10}"
+ibm_notifier_binary_name="${10}"
 
 # Check for IBM Notifier path in parameter 9. If blank, set default path
 if [ ! "$ibm_notifier_path" ]; then

--- a/Demote Admin Privileges.sh
+++ b/Demote Admin Privileges.sh
@@ -47,10 +47,9 @@ admin_to_exclude="${8}"
 # Leave blank to use default location of /Applications/IBM Notifier.app
 ibm_notifier_path="${9}"
 
-
-# Enter the binary name used in IBM Notifier if it is not standard.
+# Enter the binary for IBM Notifier if it is not standard.
 # Leave blank to use default name of 'IBM Notifier'
-ibm_notifier_binary_name="${10}"
+ibm_notifier_binary="${10}"
 
 # Check for IBM Notifier path in parameter 9. If blank, set default path
 if [ ! "$ibm_notifier_path" ]; then
@@ -58,8 +57,8 @@ if [ ! "$ibm_notifier_path" ]; then
 fi
 
 # Check for IBM Notifier binary name in parameter 10. If blank, set default path
-if [ ! "$ibm_notifier_binary_name" ]; then
-	ibm_notifier_binary_name="IBM Notifier"
+if [ ! "$ibm_notifier_binary" ]; then
+	ibm_notifier_binary="IBM Notifier"
 fi
 
 
@@ -149,7 +148,7 @@ prompt_with_ibmNotifier () {
 	
 	# Prompt the user
 	prompt_user() {
-		button=$( "${ibm_notifier_path}/Contents/MacOS/${ibm_notifier_binary_name}" \
+		button=$( "${ibm_notifier_path}/Contents/MacOS/${ibm_notifier_binary}" \
 		-type "popup" \
 		-bar_title "Privileges Reminder" \
 		-subtitle "You are currently an administrator on this device.

--- a/Demote Admin Privileges.sh
+++ b/Demote Admin Privileges.sh
@@ -56,7 +56,7 @@ if [ ! "$ibm_notifier_path" ]; then
 	ibm_notifier_path="/Applications/IBM Notifier.app"
 fi
 
-# Check for IBM Notifier binary name in parameter 10. If blank, set default path
+# Check for IBM Notifier binary in parameter 10. If blank, set default binary
 if [ ! "$ibm_notifier_binary" ]; then
 	ibm_notifier_binary="IBM Notifier"
 fi


### PR DESCRIPTION
When I was rebranding IBM Notifier for our org, I followed the guide at https://github.com/IBM/mac-ibm-notifications/wiki/Rebranding-the-application.

It may have been me interpreting it differently, but the end-result for me was that I ended-out with a rebranded binary name, in addition to the Application name itself being rebranded.

I would welcome your thoughts on this PR as to whether or not it may be included for scenarios such as mine.